### PR TITLE
Alignment of declarations' initial values

### DIFF
--- a/align-f90.el
+++ b/align-f90.el
@@ -88,6 +88,7 @@
                '(f90-declaration
                  (regexp . "[^ 	\n]\\(\\s-*\\)::\\(\\s-*\\)\\([^ 	\n]\\|$\\)")
                  (group 1 2)
+                 (separate . "entire")
                  (modes . align-f90-modes)
                  (justify . t)))
 


### PR DESCRIPTION
I've found two instances where the original alignment rules failed to do what I would expect and required the separate property to be set to "entire".  Consider the following code:

```fortran
  double precision :: solver_start
  double precision :: elapsed_time_io    = 0.0d0   
  double precision :: elapsed_time_setup
  double precision :: elapsed_time_total_timesteps       = 1e9
  double precision, allocatable, dimension(:) :: elapsed_time_cpu

  ! General use variables.                                                                                                                                                                                                     
  integer :: ii, jj
  double precision                                :: pi
  double precision, allocatable, dimension(:, :)     ::    p_rhs
```

Highlighting both blocks and aligning them as a single region yields:

```fortran
  double precision                            :: solver_start
  double precision                            :: elapsed_time_io              = 0.0d0   
  double precision                            :: elapsed_time_setup
  double precision                            :: elapsed_time_total_timesteps = 1e9
  double precision, allocatable, dimension(:) :: elapsed_time_cpu

  ! General use variables.                                                                                                                                                                                                     
  integer :: ii, jj
  double precision                               :: pi
  double precision, allocatable, dimension(:, :) :: p_rhs
```

The `ii` and `jj` variables are incorrectly aligned against the data type.

With the update I made the block above is aligned as I would expect to:

```fortran
  double precision                               :: solver_start
  double precision                               :: elapsed_time_io              = 0.0d0   
  double precision                               :: elapsed_time_setup
  double precision                               :: elapsed_time_total_timesteps = 1e9
  double precision, allocatable, dimension(:)    :: elapsed_time_cpu

  ! General use variables.                                                                                                                                                                                                     
  integer                                        :: ii, jj
  double precision                               :: pi
  double precision, allocatable, dimension(:, :) :: p_rhs
```

A slightly different version of the original block also shows incorrect behavior:

```fortran

  double precision :: solver_start
  double precision :: elapsed_time_io    = 0.0d0   
  double precision :: elapsed_time_setup
  double precision :: elapsed_time_total_timesteps       = 1e9
  double precision, allocatable, dimension(:) :: elapsed_time_cpu

  ! General use variables.                                                                                                                                                                                                     
  double precision                                :: pi
  double precision, allocatable, dimension(:, :)     ::    p_rhs
  integer :: ii, jj
```

This is incorrectly aligned to:

```fortran
  double precision                            :: solver_start
  double precision                            :: elapsed_time_io    = 0.0d0   
  double precision                            :: elapsed_time_setup
  double precision                            :: elapsed_time_total_timesteps       = 1e9
  double precision, allocatable, dimension(:) :: elapsed_time_cpu

  ! General use variables.                                                                                                                                                                                                     
  double precision :: pi
  double precision, allocatable, dimension(:, :)     ::    p_rhs
  integer :: ii, jj
```

This seems to not only not handle the second block of declarations, but got the assignment alignment of the first block wrong as well.